### PR TITLE
Implements instance EuclideanRing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.purs*
 /.psa*
 /.spago
+/package-lock.json

--- a/src/Js/BigInt/BigInt.js
+++ b/src/Js/BigInt/BigInt.js
@@ -25,7 +25,23 @@ export const biMul = (x) => (y) => x * y;
 
 export const biSub = (x) => (y) => x - y;
 
-export const biMod = (x) => (y) => x % y;
+export const biMod = (x) => (y) => {
+  if (y === 0n)
+    return 0n;
+  const yy = y < 0n ? -y : y;
+  return ((x % yy) + yy) % yy;
+}
+
+export const biDiv = (x) => (y) => {
+  if (y === 0n) return 0n;
+  const xx = x - biMod(x)(y);
+  return y > 0n ? (xx / y) : -(xx / -y);
+}
+
+export const biDegree = (x) => {
+  const xx = x < 0n ? -x : x;
+  return BigInt.asIntN(32, xx > 2147483647n ? 2147483647n : xx);
+}
 
 export const biZero = 0n;
 

--- a/src/Js/BigInt/BigInt.js
+++ b/src/Js/BigInt/BigInt.js
@@ -26,16 +26,14 @@ export const biMul = (x) => (y) => x * y;
 export const biSub = (x) => (y) => x - y;
 
 export const biMod = (x) => (y) => {
-  if (y === 0n)
-    return 0n;
+  if (y === 0n) return 0n;
   const yy = y < 0n ? -y : y;
   return ((x % yy) + yy) % yy;
 }
 
 export const biDiv = (x) => (y) => {
   if (y === 0n) return 0n;
-  const xx = x - biMod(x)(y);
-  return y > 0n ? (xx / y) : -(xx / -y);
+  return (x - biMod(x)(y)) / y;
 }
 
 export const biDegree = (x) => {

--- a/src/Js/BigInt/BigInt.purs
+++ b/src/Js/BigInt/BigInt.purs
@@ -91,9 +91,17 @@ foreign import biSub :: BigInt -> BigInt -> BigInt
 instance Ring BigInt where
   sub = biSub
 
+
 foreign import biMod :: BigInt -> BigInt -> BigInt
+foreign import biDiv :: BigInt -> BigInt -> BigInt
+foreign import biDegree :: BigInt -> Int
 
 instance CommutativeRing BigInt
+
+instance EuclideanRing BigInt where
+  degree = biDegree
+  div = biDiv
+  mod = biMod
 
 -- Raise an BigInt to the power of another BigInt.
 foreign import pow :: BigInt -> BigInt -> BigInt

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,7 +7,7 @@ import Debug (spy)
 import Effect (Effect)
 import Effect.Console (log)
 import Js.BigInt.BigInt (BigInt, and, fromInt, fromString, fromTLInt, not, or, pow, shl, shr, toString, xor)
-import Prelude (class CommutativeRing, class Eq, class Ord, class Ring, class Semiring, Unit, bind, compare, discard, identity, map, negate, one, pure, show, zero, ($), (*), (+), (-), (<$>), (<<<), (==))
+import Prelude (class CommutativeRing, class Eq, class EuclideanRing, class Ord, class Ring, class Semiring, Unit, bind, compare, discard, identity, map, negate, one, pure, show, zero, ($), (*), (+), (-), (<$>), (<<<), (==))
 import Test.Assert (assert)
 import Test.QuickCheck (quickCheck)
 import Test.QuickCheck.Arbitrary (class Arbitrary)
@@ -32,6 +32,7 @@ derive newtype instance Ord TestBigInt
 derive newtype instance Semiring TestBigInt
 derive newtype instance Ring TestBigInt
 derive newtype instance CommutativeRing TestBigInt
+derive newtype instance EuclideanRing TestBigInt
 
 instance Arbitrary TestBigInt where
   arbitrary = do
@@ -118,6 +119,7 @@ main = do
   Data.checkSemiring prxBigInt
   Data.checkRing prxBigInt
   Data.checkCommutativeRing prxBigInt
+  -- Data.checkEuclideanRing prxBigInt
 
   log "Converting BigInt to Int"
   -- assert $ (fromString "0" <#> asIntN 64) == Just 0


### PR DESCRIPTION
Implements instance EuclideanRing (mod, div and degree)

I think the implementation of mod and div are correct.
However, that does not pass the test Data.checkEuclideanRing.
This is due to the fact that the degree function must return an Int (and not a bigint). So, one needs to truncate large big ints.
and the law: "For all a and b, where b is nonzero, let q = a / b and r = a `mod` b; then a = q*b + r, and also either r = zero or **degree r < degree b**" fails for large big ints.