### PR TITLE
fix a bug on the pow function

### DIFF
--- a/src/Js/BigInt/BigInt.js
+++ b/src/Js/BigInt/BigInt.js
@@ -31,7 +31,7 @@ export const biZero = 0n;
 
 export const biOne = 1n;
 
-export const pow = (x) => (y) => y >= 0 ?  x ** y : 0;
+export const pow = (x) => (y) => y >= 0n ?  x ** y : 0n;
 
 export const not = (x) => ~x;
 


### PR DESCRIPTION
Previously, pow returned a number instead of a bigint when the exponent was negative.

For example,
```haskell
pow (fromInt 3) (fromInt (-2)) + fromInt 2
```
failed with the error "Uncaught TypeError: can't convert BigInt to number"