### PR TITLE
add new functions to match Data.Int

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "spago -x test.dhall test"
   },
   "keywords": [],
   "author": "",

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,5 +1,5 @@
 { name = "js-bigints"
-, dependencies = [ "maybe", "prelude" ]
+, dependencies = [ "integers", "maybe", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]
 , license = "MIT"

--- a/src/Js/BigInt/BigInt.js
+++ b/src/Js/BigInt/BigInt.js
@@ -71,3 +71,5 @@ export const toString = (x) => x.toString();
 
 export const asIntN = (bits) => (n) => BigInt.asIntN(bits, n);
 export const asUintN = (bits) => (n) => BigInt.asUintN(bits, n);
+
+export const toStringAs = (radix) => (i) => i.toString(radix);

--- a/src/Js/BigInt/BigInt.purs
+++ b/src/Js/BigInt/BigInt.purs
@@ -14,11 +14,18 @@ module Js.BigInt.BigInt
   , shr
   , toString
   , xor
+  , even
+  , odd
+  , parity
+  , toStringAs
+  , module Exports
   )
   where
 
 import Prelude
 
+import Data.Int (Parity(..), Radix)
+import Data.Int (Parity(..), Radix, binary, octal, decimal, hexadecimal) as Exports
 import Data.Maybe (Maybe(..))
 import Data.Reflectable (class Reflectable, reflectType)
 import Prim.Int (class ToString)
@@ -148,3 +155,32 @@ foreign import asIntN :: Int -> BigInt -> BigInt
 
 -- | Clamps a BigInt value to the given number of bits, and returns that value as an unsigned integer.
 foreign import asUintN :: Int -> BigInt -> BigInt
+
+-- | Returns whether an `BigInt` is `Even` or `Odd`.
+-- |
+-- | ``` purescript
+-- | parity (fromInt 0) == Even
+-- | parity (fromInt 1) == Odd
+-- | ```
+parity :: BigInt -> Parity
+parity n = if even n then Even else Odd
+
+-- | Returns whether an `BigInt` is an even number.
+-- |
+-- | ``` purescript
+-- | even (fromInt 0) == true
+-- | even (fromInt 1) == false
+-- | ```
+even :: BigInt -> Boolean
+even x = x `and` one == zero
+
+-- | The negation of `even`.
+-- |
+-- | ``` purescript
+-- | odd (fromInt 0) == false
+-- | odd (fromInt 1) == true
+-- | ```
+odd :: BigInt -> Boolean
+odd x = x `and` one /= zero
+
+foreign import toStringAs :: Radix -> BigInt -> String

--- a/test.dhall
+++ b/test.dhall
@@ -4,9 +4,8 @@ in      conf
     //  { sources = conf.sources # [ "test/**/*.purs" ]
         , dependencies =
               conf.dependencies
-            # [ "spec"
-              , "debug"
-              , "spec-discovery"
+            # [ "debug"
+              , "effect"
               , "quickcheck"
               , "assert"
               , "quickcheck-laws"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,8 +6,8 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Debug (spy)
 import Effect (Effect)
 import Effect.Console (log)
-import Js.BigInt.BigInt (BigInt, and, fromInt, fromString, fromTLInt, not, or, pow, shl, shr, toString, xor)
-import Prelude (class CommutativeRing, class Eq, class EuclideanRing, class Ord, class Ring, class Semiring, Unit, bind, compare, discard, identity, map, negate, one, pure, show, zero, ($), (*), (+), (-), (<$>), (<<<), (==))
+import Js.BigInt.BigInt (BigInt, and, fromInt, fromString, fromTLInt, not, or, pow, shl, shr, toString, xor, even, odd, parity, toStringAs, binary, octal)
+import Prelude (class CommutativeRing, class Eq, class EuclideanRing, class Ord, class Ring, class Semiring, Unit, bind, compare, discard, identity, map, mod, negate, one, pure, show, zero, ($), (*), (+), (-), (/), (<$>), (<<<), (==))
 import Test.Assert (assert)
 import Test.QuickCheck (quickCheck)
 import Test.QuickCheck.Arbitrary (class Arbitrary)
@@ -82,10 +82,15 @@ main = do
 
   log "Conversions between String, Int and BigInt should not loose precision"
   quickCheck (\n -> fromString (show n) == Just (fromInt n))
+  assert $ toStringAs binary (fromInt 9) == "1001"
+  assert $ toStringAs octal (fromInt 10) == "12"
 
   log "Binary relations between integers should hold before and after converting to BigInt"
   testBinary (+) (+)
   testBinary (-) (-)
+--  testBinary (*) (*)
+  testBinary mod mod
+  testBinary (/) (/)
 
   -- To test the multiplication, we need to make sure that Int does not overflow
   quickCheck (\x y -> fromSmallInt x * fromSmallInt y == fromInt (runSmallInt x * runSmallInt y))
@@ -141,3 +146,9 @@ main = do
   log "Type Level Int creation"
   assert $ toString (fromTLInt (Proxy :: Proxy 921231231322337203685124775809)) == "921231231322337203685124775809"
   assert $ toString (fromTLInt (Proxy :: Proxy (-921231231322337203685124775809))) == "-921231231322337203685124775809"
+
+  log "Parity"
+  assert $ even (fromInt 42)
+  assert $ odd (fromInt 42) == false
+  assert $ odd (fromInt 31)
+  assert $ even (fromInt 31) == false


### PR DESCRIPTION
Hi, happy new year.

add functions odd, even, parity, toStringAs
add dependency to integers in spago.dhall
import and reexport Parity, Radix, binary, octal decimal, hexadecimal from Data.Int
add new tests for div, mod, odd, even and toStringAs
remove unnecessary dependencies spec and spec-discovery from test.dhall
add a script for testing in package.json