### PR TITLE
Update BigInt.js

### DIFF
--- a/src/JS/BigInt.js
+++ b/src/JS/BigInt.js
@@ -36,7 +36,7 @@ export const fromStringAsImpl = function (just) {
 
         function f(acc, chunk) {
           let n = BigInt(parseInt(chunk, radix));
-          if (n === NaN) {
+          if (isNaN(n)) {
             throw new Error("Invalid number");
           } else {
             return acc * factor + n;


### PR DESCRIPTION
Replace the === operator with the advised isNaN function. This prevents the test to always fail.